### PR TITLE
feat: turn global requires off

### DIFF
--- a/packages/eslint-config-scotiabank-base/rules/node.js
+++ b/packages/eslint-config-scotiabank-base/rules/node.js
@@ -1,3 +1,7 @@
 module.exports = {
-  rules: {}
+  rules: {
+    // Allow require statements anywhere in a file
+    // https://eslint.org/docs/rules/global-require
+    'global-require': 'off'
+  }
 };


### PR DESCRIPTION
* under certain circumstances (in tests often) requires cannot be global
* we can still enforce global imports (es6) only via eslint-plugin-import