### PR TITLE
build(lerna): explicitly configure registry

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,7 @@
 {
   "lerna": "2.4.0",
   "npmClient": "yarn",
+  "registry": "https://registry.npmjs.org/",
   "packages": [
     "packages/*"
   ],


### PR DESCRIPTION
this fixes an issue where lerna uses the yarn registry setting instead
of npms