### PR TITLE
Update function-paren-newline rule

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/packages/eslint-config-scotiabank-base/package.json
+++ b/packages/eslint-config-scotiabank-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scotia/eslint-config-scotiabank-base",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Base ESLint configuration for Scotiabank",
   "main": "index.js",
   "repository": "git@github.com:scotiabank/eslint-config-scotiabank.git",

--- a/packages/eslint-config-scotiabank-base/rules/style.js
+++ b/packages/eslint-config-scotiabank-base/rules/style.js
@@ -20,6 +20,11 @@ module.exports = {
       ignoreRegExpLiterals: true,
       ignoreStrings: true,
       ignoreTemplateLiterals: true
-    }]
+    }],
+
+    // Enforce consistent usage of linebreaks between parenthesis
+    // Note: 'multiline' (default) not compatible with single JSX parameter
+    // https://eslint.org/docs/rules/function-paren-newline
+    'function-paren-newline': ['error', 'consistent']
   }
 };

--- a/packages/eslint-config-scotiabank-react/package.json
+++ b/packages/eslint-config-scotiabank-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scotia/eslint-config-scotiabank-react",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "ESLint configuration for Scotiabank with React support",
   "main": "index.js",
   "repository": "git@github.com:scotiabank/eslint-config-scotiabank.git",
@@ -28,7 +28,7 @@
     "eslint-plugin-react": "^7.4.0"
   },
   "dependencies": {
-    "@scotia/eslint-config-scotiabank-base": "1.1.0",
+    "@scotia/eslint-config-scotiabank-base": "1.1.1",
     "eslint-config-airbnb": "^16.1.0"
   }
 }


### PR DESCRIPTION
The default for this rule ('multiline') complains when passing a multiline JSX parameter to a function. The code below will throw errors for unexpected newlines after the first parenthesis and before the last parenthesis. The 'consistent' rule would fix these issues.

shallow(
   <Component>
       <Child>
   </Component
);
