### PR TITLE
feat: Add 'to' attribute to anchor-is-valid rule

### DIFF
--- a/packages/eslint-config-scotiabank-react/rules/react-a11y.js
+++ b/packages/eslint-config-scotiabank-react/rules/react-a11y.js
@@ -1,3 +1,11 @@
 module.exports = {
-  rules: {}
+  rules: {
+    // Ensure <a> and <Link> tags are valid (require 'href' or 'to')
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md
+    'jsx-a11y/anchor-is-valid': ['error', {
+      components: ['Link'],
+      specialLink: ['to'],
+      aspects: ['noHref', 'invalidHref', 'preferButton']
+    }]
+  }
 };


### PR DESCRIPTION
In the current AirBnb config, 

```
<Link to="/path">
```
violates the 'anchor-is-valid' accessibility rule.
The `<Link>` components wraps an `<a>` tag and this rule checks that all `<a>` tags have an href attribute. However, react-router-dom will transform the `to` prop into an `href` internally.